### PR TITLE
feat: Open-source & OpenAI-compatible LLM providers (Gemini, Anthropic, vLLM, hosted OSS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ A **hosted provider** (Groq, Together, Fireworks, OpenRouter, …) gives you ope
 ```yaml
 llm:
   provider: openai_compatible
-  model: llama-3.3-70b-versatile
+  model: qwen/qwen3.6-27b
   base_url: https://api.groq.com/openai/v1   # set LLM_API_TOKEN to your key
 ```
 
@@ -159,7 +159,13 @@ llm:
   base_url: http://your-host:8000/v1
 ```
 
-> Pick a model that supports structured outputs (Themis asks for a strict JSON schema).
+**Gemini and Anthropic** are reachable the same way as a shortcut — use `provider: gemini` or `provider: anthropic` (`base_url` defaults to the vendor's endpoint) and put your vendor key in `LLM_API_TOKEN`:
+
+```yaml
+llm:
+  provider: gemini          # or: anthropic
+  model: gemini-2.5-flash-lite   # e.g. claude-haiku-4-5 for anthropic
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Themis posts review comments directly inside your GitLab Merge Requests. The fas
 
 - ✅ **End-to-end pipeline** — include `themis-ci` in your CI pipeline and it runs on every Merge Request, posting comments automatically.
 - ✅ **OpenAI integration** — use any OpenAI model under the BYOK (Bring-Your-Own-Key) model.
+- ✅ **Open-source models** — point Themis at any OpenAI-compatible endpoint: a hosted provider (Groq, Together, Fireworks, OpenRouter, …) with just an API key, or your own self-hosted server (e.g. vLLM) — no OpenAI account required.
 - ✅ **Compliance by design** — your source code never leaves your runner; only the review request reaches the LLM you control.
 - ✅ **Context-aware reviews** — Themis loads your architecture guides and accumulated rules from past Merge Requests into the review context, producing high-signal feedback.
 - ✅ **Module inference** — once configured, Themis identifies which modules a Merge Request touches and scopes the review accordingly.
@@ -108,7 +109,7 @@ Go to your project → **Settings → CI/CD → Variables** and add both, marked
 
 | Variable | Description |
 |---|---|
-| `LLM_API_TOKEN` | API key for your LLM provider |
+| `LLM_API_TOKEN` | API key for your LLM provider. Optional for keyless self-hosted backends. |
 | `GITLAB_API_TOKEN` | Personal access token of the Themis bot account (from Step 1) |
 
 > Note: Ensure variables are not set as "Protected" because it will block passing them to the script.
@@ -135,6 +136,30 @@ llm:                      # the LLM provider and model of your choice
   provider: openai
   model: gpt-5-nano
 ```
+
+### Using open-source models
+
+Themis works with any server that exposes an **OpenAI-compatible** `/v1/chat/completions` API, so you can review with open-source models instead of OpenAI. Use `provider: openai_compatible`, point `base_url` at the endpoint, and set `LLM_API_TOKEN` only if it requires authentication. The CI runner must be able to reach `base_url`.
+
+A **hosted provider** (Groq, Together, Fireworks, OpenRouter, …) gives you open-source models with just an API key, reachable from any runner:
+
+```yaml
+llm:
+  provider: openai_compatible
+  model: llama-3.3-70b-versatile
+  base_url: https://api.groq.com/openai/v1   # set LLM_API_TOKEN to your key
+```
+
+A **self-hosted server** (e.g. [vLLM](https://docs.vllm.ai/)) keeps your code inside your own infrastructure:
+
+```yaml
+llm:
+  provider: openai_compatible
+  model: <model-name>
+  base_url: http://your-host:8000/v1
+```
+
+> Pick a model that supports structured outputs (Themis asks for a strict JSON schema).
 
 ## Contributing
 

--- a/src/bootstrap/config.py
+++ b/src/bootstrap/config.py
@@ -10,6 +10,10 @@ logger = logging.getLogger(__name__)
 THEMIS_DIR = ".themis-ai"
 DEFAULT_CONFIG_PATH = f"{THEMIS_DIR}/config.yaml"
 
+# Vendors reachable through their OpenAI-compatible endpoints.
+GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+ANTHROPIC_OPENAI_BASE_URL = "https://api.anthropic.com/v1/"
+
 RULES_SUBDIR = "rules"
 RULES_FILENAME = "rule.json"
 ARCHITECTURE_SUBDIR = "architecture"

--- a/src/bootstrap/config.py
+++ b/src/bootstrap/config.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 import logging
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 import yaml
 
 logger = logging.getLogger(__name__)
@@ -26,6 +26,7 @@ def architecture_file_path(module: str) -> str:
 
 class LLMProvider(StrEnum):
     OPENAI = "openai"
+    OPENAI_COMPATIBLE = "openai_compatible"
     ANTHROPIC = "anthropic"
     GEMINI = "gemini"
 
@@ -39,6 +40,13 @@ class ReviewConfig(BaseModel):
 class LLMConfig(BaseModel):
     provider: LLMProvider
     model: str
+    base_url: str | None = None
+
+    @model_validator(mode="after")
+    def _require_base_url_for_compatible(self) -> "LLMConfig":
+        if self.provider is LLMProvider.OPENAI_COMPATIBLE and not self.base_url:
+            raise ValueError("'base_url' is required when provider is 'openai_compatible'.")
+        return self
 
 
 class Config(BaseModel):

--- a/src/bootstrap/environment.py
+++ b/src/bootstrap/environment.py
@@ -40,12 +40,13 @@ class EnvSettings(BaseSettings):
 class Secrets(EnvSettings):
     """Sensitive tokens sourced from the process environment.
 
-    Mandatory tokens (GitLab, LLM) have no default, so :meth`load` fails if
-    they are absent. Optional tokens (Jira) default to `None` when unset.
+    The GitLab token has no default, so :meth:`load` fails if it is absent.
+    Optional tokens (LLM, Jira) default to `None` when unset; the LLM token is
+    optional because a keyless self-hosted backend needs no credential.
     """
 
     gitlab_token: str = Field(alias="GITLAB_API_TOKEN")
-    llm_token: str = Field(alias="LLM_API_TOKEN")
+    llm_token: str | None = Field(default=None, alias="LLM_API_TOKEN")
     jira_token: str | None = Field(default=None, alias="JIRA_API_TOKEN")
 
 

--- a/src/review_engine/adapters/outbound/llm/__init__.py
+++ b/src/review_engine/adapters/outbound/llm/__init__.py
@@ -1,9 +1,11 @@
 from .mock_client import MockLLMClient
 from .openai_client import OpenAIClient
+from .openai_compatible_client import OpenAICompatibleClient
 from .resolver import LLMClientResolver
 
 __all__ = [
     "MockLLMClient",
     "OpenAIClient",
+    "OpenAICompatibleClient",
     "LLMClientResolver",
 ]

--- a/src/review_engine/adapters/outbound/llm/exceptions.py
+++ b/src/review_engine/adapters/outbound/llm/exceptions.py
@@ -34,6 +34,11 @@ class LLMResponseError(LLMError):
 def handle_llm_api_errors():
     try:
         yield
+    except (openai.AuthenticationError, openai.PermissionDeniedError) as e:
+        raise LLMAPIError(
+            f"LLM provider rejected the credentials (HTTP {e.status_code}) — check LLM_API_TOKEN.",
+            status_code=e.status_code,
+        ) from e
     except openai.APIStatusError as e:
         raise LLMAPIError(
             f"LLM provider returned HTTP {e.status_code}", status_code=e.status_code

--- a/src/review_engine/adapters/outbound/llm/openai_compatible_client.py
+++ b/src/review_engine/adapters/outbound/llm/openai_compatible_client.py
@@ -12,11 +12,22 @@ from .prompt import build_system_prompt, build_user_prompt
 
 logger = logging.getLogger(__name__)
 
+# Keyless servers (e.g. a self-hosted vLLM) ignore the key, but the OpenAI SDK
+# still requires a non-empty one to build the client. "EMPTY" is the conventional
+# placeholder used by the vLLM docs for exactly this case.
+_PLACEHOLDER_API_KEY = "EMPTY"
 
-class OpenAIClient(LLMPort):
-    def __init__(self, model: str, token: str | None):
+
+class OpenAICompatibleClient(LLMPort):
+    """Talks to any OpenAI-compatible server (self-hosted vLLM/LM Studio, or hosted OSS providers).
+
+    Unlike :class:`OpenAIClient`, which uses the OpenAI-only Responses API, this
+    adapter speaks the Chat Completions API that every compatible backend exposes.
+    """
+
+    def __init__(self, model: str, base_url: str, token: str | None = None):
         self.model = model
-        self._client = OpenAI(api_key=token)
+        self._client = OpenAI(base_url=base_url, api_key=token or _PLACEHOLDER_API_KEY)
 
     def generate_code_review(self, mr: MergeRequest, context: AnalysisContext) -> CodeReview:
         dto = self._request_review(mr, context)
@@ -43,26 +54,31 @@ class OpenAIClient(LLMPort):
         )
 
         with handle_llm_api_errors():
-            response = self._client.responses.parse(
+            response = self._client.chat.completions.parse(
                 model=self.model,
-                input=[
+                messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
-                text_format=CodeReviewResponseDTO,
+                response_format=CodeReviewResponseDTO,
             )
 
-        logger.debug("Raw LLM response output_text:\n%s", getattr(response, "output_text", None))
+        message = response.choices[0].message
+        logger.debug("Raw LLM response content:\n%s", message.content)
+
+        if message.refusal:
+            raise LLMResponseError(f"LLM refused to respond: {message.refusal}")
 
         with handle_llm_data_errors():
-            dto: CodeReviewResponseDTO | None = response.output_parsed
+            dto: CodeReviewResponseDTO | None = message.parsed
 
         if dto is None:
-            raise LLMResponseError("LLM returned no parsable structured output (possible refusal).")
+            raise LLMResponseError("LLM returned no parsable structured output.")
 
         logger.debug("Parsed LLM response DTO:\n%s", dto.model_dump_json(indent=2))
         logger.info(
-            f"LLM responded with {len(dto.code_review_comments)} comments and identified {len(dto.cohorts)} cohorts"
+            f"LLM responded with {len(dto.code_review_comments)} comments "
+            f"and identified {len(dto.cohorts)} cohorts"
         )
 
         return dto

--- a/src/review_engine/adapters/outbound/llm/resolver.py
+++ b/src/review_engine/adapters/outbound/llm/resolver.py
@@ -3,19 +3,25 @@ from src.review_engine.ports.outbound import LLMPort
 
 from .mock_client import MockLLMClient
 from .openai_client import OpenAIClient
+from .openai_compatible_client import OpenAICompatibleClient
 
 
 class LLMClientResolver:
     """Selects the concrete LLM adapter for the configured provider."""
 
     @staticmethod
-    def resolve(llm_config: LLMConfig, token: str, test_mode: bool) -> LLMPort:
+    def resolve(llm_config: LLMConfig, token: str | None, test_mode: bool) -> LLMPort:
         if test_mode:
             return MockLLMClient()
 
         match llm_config.provider:
             case LLMProvider.OPENAI:
                 return OpenAIClient(model=llm_config.model, token=token)
+            case LLMProvider.OPENAI_COMPATIBLE:
+                assert llm_config.base_url is not None
+                return OpenAICompatibleClient(
+                    model=llm_config.model, base_url=llm_config.base_url, token=token
+                )
             case _:
                 raise NotImplementedError(
                     f"LLM provider '{llm_config.provider}' is not supported yet."

--- a/src/review_engine/adapters/outbound/llm/resolver.py
+++ b/src/review_engine/adapters/outbound/llm/resolver.py
@@ -1,9 +1,20 @@
-from src.bootstrap.config import LLMConfig, LLMProvider
+from src.bootstrap.config import (
+    ANTHROPIC_OPENAI_BASE_URL,
+    GEMINI_OPENAI_BASE_URL,
+    LLMConfig,
+    LLMProvider,
+)
 from src.review_engine.ports.outbound import LLMPort
 
 from .mock_client import MockLLMClient
 from .openai_client import OpenAIClient
 from .openai_compatible_client import OpenAICompatibleClient
+
+# Vendors served through OpenAICompatibleClient with a default base_url the user may override.
+_DEFAULT_OPENAI_COMPATIBLE_BASE_URLS = {
+    LLMProvider.GEMINI: GEMINI_OPENAI_BASE_URL,
+    LLMProvider.ANTHROPIC: ANTHROPIC_OPENAI_BASE_URL,
+}
 
 
 class LLMClientResolver:
@@ -17,10 +28,15 @@ class LLMClientResolver:
         match llm_config.provider:
             case LLMProvider.OPENAI:
                 return OpenAIClient(model=llm_config.model, token=token)
-            case LLMProvider.OPENAI_COMPATIBLE:
-                assert llm_config.base_url is not None
+            case LLMProvider.OPENAI_COMPATIBLE | LLMProvider.GEMINI | LLMProvider.ANTHROPIC:
+                base_url = llm_config.base_url or _DEFAULT_OPENAI_COMPATIBLE_BASE_URLS.get(
+                    llm_config.provider
+                )
+                # openai_compatible always has a base_url (LLMConfig validator); the
+                # vendors fall back to their default above.
+                assert base_url is not None
                 return OpenAICompatibleClient(
-                    model=llm_config.model, base_url=llm_config.base_url, token=token
+                    model=llm_config.model, base_url=base_url, token=token
                 )
             case _:
                 raise NotImplementedError(

--- a/tests/unit/bootstrap/test_config.py
+++ b/tests/unit/bootstrap/test_config.py
@@ -30,6 +30,15 @@ llm:
   model: gpt-4o
 """
 
+_OPENAI_COMPATIBLE_CONFIG = """
+version: 1
+
+llm:
+  provider: openai_compatible
+  model: qwen2.5-coder
+  base_url: http://localhost:8000/v1
+"""
+
 
 def _write_config(tmp_path: Path, body: str) -> str:
     path = tmp_path / "config.yaml"
@@ -105,3 +114,17 @@ def test_custom_path_argument_is_honoured(tmp_path: Path) -> None:
     config = Config.from_yaml(str(path))
 
     assert config.llm.model == "claude-opus-4-8"
+
+
+def test_openai_compatible_provider_loads_base_url(tmp_path: Path) -> None:
+    config = Config.from_yaml(_write_config(tmp_path, _OPENAI_COMPATIBLE_CONFIG))
+
+    assert config.llm.provider is LLMProvider.OPENAI_COMPATIBLE
+    assert config.llm.base_url == "http://localhost:8000/v1"
+
+
+def test_openai_compatible_provider_requires_base_url(tmp_path: Path) -> None:
+    body = _OPENAI_COMPATIBLE_CONFIG.replace("  base_url: http://localhost:8000/v1\n", "")
+
+    with pytest.raises(ValidationError, match="base_url"):
+        Config.from_yaml(_write_config(tmp_path, body))

--- a/tests/unit/bootstrap/test_secrets.py
+++ b/tests/unit/bootstrap/test_secrets.py
@@ -27,6 +27,16 @@ def test_jira_token_defaults_to_none_when_absent(
     assert secrets.jira_token is None
 
 
+def test_llm_token_defaults_to_none_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITLAB_API_TOKEN", "gl-token")
+
+    secrets = Secrets.load()
+
+    assert secrets.llm_token is None
+
+
 def test_unrelated_env_vars_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITLAB_API_TOKEN", "gl-token")
     monkeypatch.setenv("LLM_API_TOKEN", "llm-token")
@@ -41,19 +51,19 @@ def test_unrelated_env_vars_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None
 def test_missing_single_mandatory_token_reports_that_variable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("GITLAB_API_TOKEN", "gl-token")
+    monkeypatch.setenv("LLM_API_TOKEN", "llm-token")
 
     with pytest.raises(MissingEnvironmentError) as exc_info:
         Secrets.load()
 
-    assert exc_info.value.variables == ["LLM_API_TOKEN"]
+    assert exc_info.value.variables == ["GITLAB_API_TOKEN"]
 
 
-def test_missing_all_mandatory_tokens_reports_each_variable(
+def test_missing_mandatory_token_reports_variable_with_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     with pytest.raises(MissingEnvironmentError) as exc_info:
         Secrets.load()
 
-    assert set(exc_info.value.variables) == {"GITLAB_API_TOKEN", "LLM_API_TOKEN"}
+    assert set(exc_info.value.variables) == {"GITLAB_API_TOKEN"}
     assert "Missing essential environment variables" in str(exc_info.value)

--- a/tests/unit/review_engine/adapters/outbound/llm/test_exceptions.py
+++ b/tests/unit/review_engine/adapters/outbound/llm/test_exceptions.py
@@ -1,0 +1,38 @@
+import httpx
+import openai
+import pytest
+
+from src.review_engine.adapters.outbound.llm.exceptions import LLMAPIError, handle_llm_api_errors
+
+
+def _response(status_code: int) -> httpx.Response:
+    request = httpx.Request("POST", "https://provider.test/v1/chat/completions")
+    return httpx.Response(status_code, request=request)
+
+
+def test_authentication_error_points_at_the_token() -> None:
+    with pytest.raises(LLMAPIError) as exc_info:
+        with handle_llm_api_errors():
+            raise openai.AuthenticationError("Unauthorized", response=_response(401), body=None)
+
+    assert exc_info.value.status_code == 401
+    assert "LLM_API_TOKEN" in str(exc_info.value)
+
+
+def test_permission_denied_points_at_the_token() -> None:
+    with pytest.raises(LLMAPIError) as exc_info:
+        with handle_llm_api_errors():
+            raise openai.PermissionDeniedError("Forbidden", response=_response(403), body=None)
+
+    assert exc_info.value.status_code == 403
+    assert "LLM_API_TOKEN" in str(exc_info.value)
+
+
+def test_other_status_errors_keep_a_plain_message() -> None:
+    with pytest.raises(LLMAPIError) as exc_info:
+        with handle_llm_api_errors():
+            raise openai.NotFoundError("Missing", response=_response(404), body=None)
+
+    assert exc_info.value.status_code == 404
+    assert "404" in str(exc_info.value)
+    assert "LLM_API_TOKEN" not in str(exc_info.value)

--- a/tests/unit/review_engine/adapters/outbound/llm/test_openai_compatible_client.py
+++ b/tests/unit/review_engine/adapters/outbound/llm/test_openai_compatible_client.py
@@ -1,0 +1,74 @@
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+
+from src.review_engine.adapters.outbound.llm.dto import CodeReviewResponseDTO, CommentDTO
+from src.review_engine.adapters.outbound.llm.exceptions import LLMResponseError
+from src.review_engine.adapters.outbound.llm.openai_compatible_client import OpenAICompatibleClient
+from src.review_engine.domain.models import AnalysisContext, MergeRequest
+from tests.unit.review_engine.domain.factories import MergeRequestFactory
+
+_BASE_URL = "http://localhost:11434/v1"
+
+
+def _merge_request() -> MergeRequest:
+    # factory-boy's typing does not narrow the call to the model type.
+    return cast(MergeRequest, MergeRequestFactory())
+
+
+def _dto(comment_content: str) -> CodeReviewResponseDTO:
+    return CodeReviewResponseDTO(
+        cohorts=[],
+        business_requirements_matrix=[],
+        code_review_comments=[CommentDTO(content=comment_content, references=[])],
+    )
+
+
+def _stub_response(parsed: CodeReviewResponseDTO | None, refusal: str | None = None) -> Mock:
+    message = Mock(parsed=parsed, refusal=refusal, content="raw-content")
+    return Mock(choices=[Mock(message=message)])
+
+
+def _client_returning(response: Mock) -> OpenAICompatibleClient:
+    mock_client = Mock()
+    mock_client.chat.completions.parse.return_value = response
+    client = OpenAICompatibleClient(model="qwen2.5-coder", base_url=_BASE_URL)
+    client._client = mock_client
+    return client
+
+
+def test_generate_code_review_maps_parsed_dto_to_domain() -> None:
+    client = _client_returning(_stub_response(_dto("A real bug.")))
+
+    review = client.generate_code_review(_merge_request(), AnalysisContext())
+
+    assert review.comments[0].content == "A real bug."
+
+
+def test_request_asks_for_structured_output_via_chat_completions() -> None:
+    parse = Mock(return_value=_stub_response(_dto("x")))
+    mock_client = Mock()
+    mock_client.chat.completions.parse = parse
+    client = OpenAICompatibleClient(model="qwen2.5-coder", base_url=_BASE_URL)
+    client._client = mock_client
+
+    client.generate_code_review(_merge_request(), AnalysisContext())
+
+    _, kwargs = parse.call_args
+    assert kwargs["response_format"] is CodeReviewResponseDTO
+    assert [message["role"] for message in kwargs["messages"]] == ["system", "user"]
+
+
+def test_refusal_raises_response_error() -> None:
+    client = _client_returning(_stub_response(None, refusal="I cannot help."))
+
+    with pytest.raises(LLMResponseError):
+        client.generate_code_review(_merge_request(), AnalysisContext())
+
+
+def test_missing_parsed_output_raises_response_error() -> None:
+    client = _client_returning(_stub_response(None))
+
+    with pytest.raises(LLMResponseError):
+        client.generate_code_review(_merge_request(), AnalysisContext())

--- a/tests/unit/review_engine/adapters/outbound/llm/test_resolver.py
+++ b/tests/unit/review_engine/adapters/outbound/llm/test_resolver.py
@@ -32,3 +32,32 @@ def test_resolves_openai_compatible_with_configured_base_url() -> None:
 
     assert isinstance(client, OpenAICompatibleClient)
     assert "remote-host:8000/v1" in str(client._client.base_url)
+
+
+def test_resolves_gemini_through_openai_compatible_client() -> None:
+    config = LLMConfig(provider=LLMProvider.GEMINI, model="gemini-2.0-flash")
+
+    client = LLMClientResolver.resolve(config, token="key", test_mode=False)
+
+    assert isinstance(client, OpenAICompatibleClient)
+    assert "generativelanguage.googleapis.com" in str(client._client.base_url)
+
+
+def test_resolves_anthropic_through_openai_compatible_client() -> None:
+    config = LLMConfig(provider=LLMProvider.ANTHROPIC, model="claude-3-5-haiku-latest")
+
+    client = LLMClientResolver.resolve(config, token="key", test_mode=False)
+
+    assert isinstance(client, OpenAICompatibleClient)
+    assert "api.anthropic.com" in str(client._client.base_url)
+
+
+def test_default_vendor_base_url_can_be_overridden() -> None:
+    config = LLMConfig(
+        provider=LLMProvider.GEMINI, model="gemini-2.0-flash", base_url="http://proxy:8080/v1"
+    )
+
+    client = LLMClientResolver.resolve(config, token="key", test_mode=False)
+
+    assert isinstance(client, OpenAICompatibleClient)
+    assert "proxy:8080/v1" in str(client._client.base_url)

--- a/tests/unit/review_engine/adapters/outbound/llm/test_resolver.py
+++ b/tests/unit/review_engine/adapters/outbound/llm/test_resolver.py
@@ -1,0 +1,34 @@
+from src.bootstrap.config import LLMConfig, LLMProvider
+from src.review_engine.adapters.outbound.llm.mock_client import MockLLMClient
+from src.review_engine.adapters.outbound.llm.openai_client import OpenAIClient
+from src.review_engine.adapters.outbound.llm.openai_compatible_client import OpenAICompatibleClient
+from src.review_engine.adapters.outbound.llm.resolver import LLMClientResolver
+
+
+def test_test_mode_returns_mock_client() -> None:
+    config = LLMConfig(provider=LLMProvider.OPENAI, model="gpt-4o")
+
+    client = LLMClientResolver.resolve(config, token="t", test_mode=True)
+
+    assert isinstance(client, MockLLMClient)
+
+
+def test_resolves_openai_provider_to_openai_client() -> None:
+    config = LLMConfig(provider=LLMProvider.OPENAI, model="gpt-4o")
+
+    client = LLMClientResolver.resolve(config, token="t", test_mode=False)
+
+    assert isinstance(client, OpenAIClient)
+
+
+def test_resolves_openai_compatible_with_configured_base_url() -> None:
+    config = LLMConfig(
+        provider=LLMProvider.OPENAI_COMPATIBLE,
+        model="llama3.1",
+        base_url="http://remote-host:8000/v1",
+    )
+
+    client = LLMClientResolver.resolve(config, token="t", test_mode=False)
+
+    assert isinstance(client, OpenAICompatibleClient)
+    assert "remote-host:8000/v1" in str(client._client.base_url)


### PR DESCRIPTION
Closes #16

## What & why
Themis only supported OpenAI. This adds a generic `openai_compatible` provider so reviews can run against any OpenAI-compatible endpoint — a self-hosted vLLM, hosted OSS providers (Groq/Together/Fireworks/OpenRouter), and Gemini/Anthropic via their OpenAI-compatible endpoints — by setting `base_url` (+ optional `LLM_API_TOKEN`).

## How
- `OpenAICompatibleClient` uses the **Chat Completions API** (`chat.completions.parse`), which these servers implement — unlike the OpenAI-only Responses API used by `OpenAIClient`. Reuses the shared DTOs, mappers, prompts, and error handling.
- `LLMConfig` gains an optional `base_url`, validated as required for `openai_compatible`.
- `gemini` and `anthropic` route through the same client, each defaulting to the vendor's OpenAI-compatible endpoint (overridable via `base_url`).
- `LLM_API_TOKEN` is now optional (keyless self-hosted backends); 401/403 surface a credential hint pointing at it.

## Tested
`ruff` + `ruff format` + `ty` clean; 69 unit tests. Live end-to-end with structured outputs: Gemini `gemini-3.1-flash-lite` ✅ and Anthropic `claude-haiku-4-5` ✅.

## Notes
Domain, orchestrator, ports, and CLI are untouched — provider selection happens in the resolver behind `LLMPort`. Native dedicated adapters (Anthropic Messages API / Gemini API) remain possible later.
